### PR TITLE
Lazy-load SVG icon sprite

### DIFF
--- a/callbackify.js
+++ b/callbackify.js
@@ -1,0 +1,16 @@
+import utils from "../utils.js";
+
+const callbackify = (fn, reducer) => {
+  return utils.isAsyncFn(fn) ? function (...args) {
+    const cb = args.pop();
+    fn.apply(this, args).then((value) => {
+      try {
+        reducer ? cb(null, ...reducer(value)) : cb(null, value);
+      } catch (err) {
+        cb(err);
+      }
+    }, cb);
+  } : fn;
+}
+
+export default callbackify;


### PR DESCRIPTION
Reduce initial bundle and improve TTFB by deferring the icon sprite until needed. Replace the inline sprite import with a dynamic import and load it via IntersectionObserver/on-first-interaction so icons are fetched only when used.